### PR TITLE
feat: Add native Fedora RPM build

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,7 +8,7 @@ jobs:
   Build_for_DEB:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: "sudo apt update"
       - run: "sudo apt install -y gcc g++ autotools-dev fuse3 libfuse-dev libfuse3-dev libattr1-dev alien"
       - run: "mkdir -p packaging/debian/usr/bin"
@@ -18,32 +18,42 @@ jobs:
       - run: "ln -s cicpoffs packaging/debian/usr/bin/mount.cicpoffs"
       - run: "dpkg-deb --build packaging/debian"
       - run: "cp packaging/debian.deb packaging/cicpoffs.deb"
-      - run: "cd packaging; sudo alien -r -c -v debian.deb; cd .."
-      - run: "cd packaging; mv $(ls -1 | grep cicpoffs | grep rpm | head -1) debian.rpm; cd .."
-      - run: "cp packaging/debian.rpm packaging/cicpoffs.rpm"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cicpoffs.deb
           path: packaging/debian.deb
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cicpoffs.rpm
-          path: packaging/debian.rpm
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: packaging/cicpoffs.*
+          file: packaging/cicpoffs.deb
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true
+  Build_for_RPM:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: "docker run --rm -v ./:/repo fedora:44 /bin/bash /repo/packaging/fedora/build.sh"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cicpoffs.rpm
+          path: packaging/cicpoffs.rpm
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: packaging/cicpoffs.rpm
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
   Build_for_ARCH:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: "docker run --rm -v ./:/repo archlinux /bin/bash /repo/packaging/arch/bash.sh"
       - run: "sudo cp packaging/arch/cicpoffs.tar.zst packaging/cicpoffs.tar.zst"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cicpoffs.tar.zst
           path: packaging/arch/cicpoffs.tar.zst

--- a/packaging/fedora/build.sh
+++ b/packaging/fedora/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+cd /repo
+dnf install -y gcc-c++ fuse3-devel libattr-devel make rpm-build
+mkdir -p /root/rpmbuild/{SOURCES,SPECS}
+tar czf /root/rpmbuild/SOURCES/cicpoffs-src.tar.gz --transform='s,^\.,cicpoffs-src,' -C /repo .
+cp packaging/fedora/cicpoffs.spec /root/rpmbuild/SPECS/
+rpmbuild -bb /root/rpmbuild/SPECS/cicpoffs.spec
+cp /root/rpmbuild/RPMS/x86_64/cicpoffs-*.rpm /repo/packaging/cicpoffs.rpm

--- a/packaging/fedora/cicpoffs.spec
+++ b/packaging/fedora/cicpoffs.spec
@@ -1,0 +1,32 @@
+Name:           cicpoffs
+Version:        0.3
+Release:        1%{?dist}
+Summary:        Case-Insensitive Case-Preserving Overlay FUSE File System
+License:        GPLv2
+URL:            https://github.com/ublue-os/cicpoffs
+Source0:        cicpoffs-src.tar.gz
+
+%global debug_package %{nil}
+
+BuildRequires:  gcc-c++
+BuildRequires:  fuse3-devel
+BuildRequires:  libattr-devel
+BuildRequires:  make
+Requires:       fuse3-libs
+
+%description
+Case-Insensitive Case-Preserving Overlay FUSE File System
+
+%prep
+%setup -q -n cicpoffs-src
+
+%build
+make cicpoffs
+
+%install
+install -Dm755 cicpoffs %{buildroot}%{_bindir}/cicpoffs
+ln -s cicpoffs %{buildroot}%{_bindir}/mount.cicpoffs
+
+%files
+%{_bindir}/cicpoffs
+%{_bindir}/mount.cicpoffs


### PR DESCRIPTION
The current RPM is built via `alien` from a Debian package on Ubuntu, which bakes in a dependency on `libfuse3.so.3`. Fedora 44 ships `fuse3-libs` with `libfuse3.so.4`, so the existing RPM can't be installed on Fedora 44-based images (e.g. Bazzite).

This adds a `Build_for_RPM` job that builds the RPM natively in a Fedora 44 container using `rpmbuild`, producing `cicpoffs.rpm` with the correct `libfuse3.so.4` dependency.