### PR TITLE
Build separate RPMs for Fedora 43 and 44

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -32,18 +32,21 @@ jobs:
           file_glob: true
   Build_for_RPM:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fedora_version: [43, 44]
     steps:
       - uses: actions/checkout@v6
-      - run: "docker run --rm -v ./:/repo fedora:44 /bin/bash /repo/packaging/fedora/build.sh"
+      - run: "docker run --rm -v ./:/repo fedora:${{ matrix.fedora_version }} /bin/bash /repo/packaging/fedora/build.sh ${{ matrix.fedora_version }}"
       - uses: actions/upload-artifact@v7
         with:
-          name: cicpoffs.rpm
-          path: packaging/cicpoffs.rpm
+          name: cicpoffs-fc${{ matrix.fedora_version }}.rpm
+          path: packaging/cicpoffs-fc${{ matrix.fedora_version }}.rpm
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: packaging/cicpoffs.rpm
+          file: packaging/cicpoffs-fc${{ matrix.fedora_version }}.rpm
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true

--- a/packaging/fedora/build.sh
+++ b/packaging/fedora/build.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -euo pipefail
+
+FEDORA_VERSION="${1:?Usage: build.sh <fedora_version>}"
+
 cd /repo
 dnf install -y gcc-c++ fuse3-devel libattr-devel make rpm-build
 mkdir -p /root/rpmbuild/{SOURCES,SPECS}
 tar czf /root/rpmbuild/SOURCES/cicpoffs-src.tar.gz --transform='s,^\.,cicpoffs-src,' -C /repo .
 cp packaging/fedora/cicpoffs.spec /root/rpmbuild/SPECS/
 rpmbuild -bb /root/rpmbuild/SPECS/cicpoffs.spec
-cp /root/rpmbuild/RPMS/x86_64/cicpoffs-*.rpm /repo/packaging/cicpoffs.rpm
+cp /root/rpmbuild/RPMS/x86_64/cicpoffs-*.rpm "/repo/packaging/cicpoffs-fc${FEDORA_VERSION}.rpm"


### PR DESCRIPTION
libfuse ABI differs between versions. Produce a per-version RPM so bazzite can install the correct one.